### PR TITLE
Set the charge control value null after match statement in order to …

### DIFF
--- a/ViennaAdvantage/Areas/VA012/Scripts/apps/forms/bankstatement.js
+++ b/ViennaAdvantage/Areas/VA012/Scripts/apps/forms/bankstatement.js
@@ -4789,6 +4789,8 @@
                                         _cmbStatementNo.prop('selectedIndex', 0);
                                         // _cmbChargeType.prop('selectedIndex', 0);
                                         $ChargeControl.value = null;
+                                        //Handled to set value as null for charge control after match statement
+                                        $ChargeControl.setValue(null);
                                         _cmbTaxRate.prop('selectedIndex', 0);
 
                                         _matchingBaseItemList = [];


### PR DESCRIPTION
…avoid error message